### PR TITLE
Removed unnecessary isClient check

### DIFF
--- a/src/Core/Shared/Modules/Agent/Buff/Effects/Camera.lua
+++ b/src/Core/Shared/Modules/Agent/Buff/Effects/Camera.lua
@@ -1,5 +1,5 @@
 local isClient = game:GetService("RunService"):IsClient()
-local localPlayer = isClient and game:GetService("Players").LocalPlayer
+local localPlayer = game:GetService("Players").LocalPlayer
 
 if not isClient then
     warn(("'%s' buff effect cannnot be used on the server!"):format(script.Name))


### PR DESCRIPTION
I've removed the check for `isClient` when declaring `localPlayer`, since `Players.LocalPlayer` defaults to `nil` if there is no local player.

This might just be for good practice, so feel free to close this PR in that case.